### PR TITLE
Global upsert option not functioning properly

### DIFF
--- a/src/datastore/async_methods/create.js
+++ b/src/datastore/async_methods/create.js
@@ -11,8 +11,7 @@ function create(resourceName, attrs, options) {
   var rejectionError;
   if (!definition) {
     rejectionError = new DSErrors.NER(resourceName);
-  }
-  if (definition) {
+  } else {
     options = DSUtils._(definition, options);
     if (options.upsert && (DSUtils.isString(attrs) || DSUtils.isNumber(attrs))) {
       return _this.update(resourceName, attrs, _this.get(resourceName, attrs), options);


### PR DESCRIPTION
The problem is that the line

`if (definition && options.upsert && attrs[definition.idAttribute]) {`

runs before

`options = DSUtils._(definition, options);`

so the options don't get merged with the global options. This is a suggested fix.
