### PR TITLE
Adds create as an instance method

### DIFF
--- a/src/datastore/sync_methods/defineResource.js
+++ b/src/datastore/sync_methods/defineResource.js
@@ -16,6 +16,7 @@ function Resource(options) {
 var instanceMethods = [
   'compute',
   'refresh',
+  'create',
   'save',
   'update',
   'destroy',


### PR DESCRIPTION
Adds create instance method so I can do:

``` javascript
var foo = Foo.createInstance({});
foo.DSCreate();
```
