### PR TITLE
Changing !Schemator to DSUtils.isEmpty(Schemator)

### DIFF
--- a/src/datastore/index.js
+++ b/src/datastore/index.js
@@ -311,7 +311,7 @@ function DS(options) {
   } catch (e) {
   }
 
-  if (!Schemator) {
+  if (DSUtils.isEmpty(Schemator)) {
     try {
       Schemator = window.Schemator;
     } catch (e) {


### PR DESCRIPTION
For some reason, webpack returns an empty object with `require('js-data-schema')`. Changing this line should fix that issue without breaking anything else.