### PR TITLE
bug: getAdapter when called from a Resource fails

### DIFF
--- a/src/datastore/index.js
+++ b/src/datastore/index.js
@@ -337,6 +337,10 @@ function DS(options) {
 var dsPrototype = DS.prototype;
 
 dsPrototype.getAdapter = function (options) {
+  // when called from a Resource, the first argument is the resource name
+  if (arguments.length === 2) {
+    options = arguments[1];
+  }
   var errorIfNotExist = false;
   options = options || {};
   this.defaults.logFn('getAdapter', options);


### PR DESCRIPTION
When the getAdapter method on a Resource is called, the first argument is always the resource name as set here: https://github.com/js-data/js-data/blob/master/src/datastore/sync_methods/defineResource.js#L289-L291

The fix I suggest is simply to check for the argument length, and set options accordingly. It's a little ugly but it works. What do you think? Is there a better way to achieve this?