### PR TITLE
Don't link relations where localField is undefined

### DIFF
--- a/src/datastore/sync_methods/link.js
+++ b/src/datastore/sync_methods/link.js
@@ -21,7 +21,7 @@ export default function link(resourceName, id, relations) {
   if (linked) {
     DSUtils.forEach(definition.relationList, def => {
       let relationName = def.relation;
-      if (relations.length && !DSUtils.contains(relations, relationName)) {
+      if ((relations.length && !DSUtils.contains(relations, relationName)) || !def.localField) {
         return;
       }
       let params = {};

--- a/src/datastore/sync_methods/linkAll.js
+++ b/src/datastore/sync_methods/linkAll.js
@@ -18,7 +18,7 @@ export default function linkAll(resourceName, params, relations) {
   if (linked) {
     DSUtils.forEach(definition.relationList, def => {
       let relationName = def.relation;
-      if (relations.length && !DSUtils.contains(relations, relationName)) {
+      if ((relations.length && !DSUtils.contains(relations, relationName)) || !def.localField) {
         return;
       }
       if (def.type === 'belongsTo') {

--- a/test/both/datastore/sync_methods/link.test.js
+++ b/test/both/datastore/sync_methods/link.test.js
@@ -61,4 +61,45 @@ describe('DS#link', function () {
     assert.isUndefined(user99.profile);
     assert.equal(2, org66.users.length);
   });
+
+  it('should not link resources if localField is not specified', function () {
+    store.defineResource({
+      name: 'water',
+      relations: {
+        hasOne: {
+          oxygen: {
+            foreignKey: 'atomId'
+          }
+        }
+      }
+    });
+    store.defineResource({
+      name: 'oxygen',
+      relations: {
+        belongsTo: {
+          water: {
+            localKey: 'moleculeId'
+          }
+        }
+      }
+    });
+    var water = store.inject('water', {
+      id: 21,
+      atomId: 41
+    });
+    var oxygen = store.inject('oxygen', {
+      id: 41,
+      moleculeId: 21
+    });
+
+    store.link('water', 21, []);
+    store.link('oxygen', 41, []);
+    
+    Object.keys(water).forEach(function(key) {
+      assert.isTrue(water[key] !== oxygen);
+    });
+    Object.keys(oxygen).forEach(function(key) {
+      assert.isTrue(oxygen[key] !== water);
+    });
+  });
 });

--- a/test/both/datastore/sync_methods/linkAll.test.js
+++ b/test/both/datastore/sync_methods/linkAll.test.js
@@ -58,4 +58,45 @@ describe('DS#linkAll', function () {
     assert.isUndefined(user99.profile);
     assert.equal(2, org66.users.length);
   });
+
+  it('should not link resources if localField is not specified', function () {
+    store.defineResource({
+      name: 'water',
+      relations: {
+        hasOne: {
+          oxygen: {
+            foreignKey: 'atomId'
+          }
+        }
+      }
+    });
+    store.defineResource({
+      name: 'oxygen',
+      relations: {
+        belongsTo: {
+          water: {
+            localKey: 'moleculeId'
+          }
+        }
+      }
+    });
+    var water = store.inject('water', {
+      id: 21,
+      atomId: 41
+    });
+    var oxygen = store.inject('oxygen', {
+      id: 41,
+      moleculeId: 21
+    });
+
+    store.linkAll('water');
+    store.linkAll('oxygen');
+
+    Object.keys(water).forEach(function(key) {
+      assert.isTrue(water[key] !== oxygen);
+    });
+    Object.keys(oxygen).forEach(function(key) {
+      assert.isTrue(oxygen[key] !== water);
+    });
+  });
 });


### PR DESCRIPTION
When localField is not defined the relation is linked under the field "undefined", this doesn't make much since. I propose to rather skip linking if the field is not defined. This makes it possible to intentionally not link up a resource when that is needed.