### PR TITLE
loadRelations: check params.where instead when allowSimpleWhere is disabled

### DIFF
--- a/src/datastore/async_methods/loadRelations.js
+++ b/src/datastore/async_methods/loadRelations.js
@@ -38,21 +38,22 @@ export default function loadRelations(resourceName, instance, relations, options
         if (DSUtils.contains(relations, relationName) || DSUtils.contains(relations, def.localField)) {
           let task;
           let params = {};
+          let where;
           if (__options.allowSimpleWhere) {
             params[def.foreignKey] = instance[definition.idAttribute];
+            where = params;
           } else {
             params.where = {};
-            params.where[def.foreignKey] = {
-              '==': instance[definition.idAttribute]
-            };
+            params.where[def.foreignKey] = instance[definition.idAttribute];
+            where = params.where;
           }
 
-          if (def.type === 'hasMany' && params[def.foreignKey]) {
+          if (def.type === 'hasMany' && where[def.foreignKey]) {
             task = _this.findAll(relationName, params, __options.orig());
           } else if (def.type === 'hasOne') {
             if (def.localKey && instance[def.localKey]) {
               task = _this.find(relationName, instance[def.localKey], __options.orig());
-            } else if (def.foreignKey && params[def.foreignKey]) {
+            } else if (def.foreignKey && where[def.foreignKey]) {
               task = _this.findAll(relationName, params, __options.orig()).then(hasOnes => hasOnes.length ? hasOnes[0] : null);
             }
           } else if (instance[def.localKey]) {

--- a/test/browser/datastore/async_methods/loadRelations.test.js
+++ b/test/browser/datastore/async_methods/loadRelations.test.js
@@ -372,4 +372,22 @@ describe('DS#loadRelations', function () {
       }
     }, 30);
   });
+  it('should get an item from the server with allowSimpleWhere disabled', function (done) {
+    var _this = this;
+    store.inject('user', user10);
+
+    store.loadRelations('user', 10, ['profile'], { allowSimpleWhere: false, bypassCache: true });
+
+    setTimeout(function () {
+      try {
+        assert.equal(1, _this.requests.length);
+        assert.equal(_this.requests[0].url, 'http://test.js-data.io/profile?where=%7B%22userId%22:10%7D');
+        assert.equal(_this.requests[0].method, 'GET');
+        done();
+      } catch (err) {
+        done(err.stack);
+      }
+    }, 30);
+
+  });
 });


### PR DESCRIPTION
Hi,

you are doing a really great job with this project, thank you !

I encounter a problem when using loadRelations with allowSimpleWhere disabled, so I try my best to send you a test case with a PR.

Without this, the .findAll is never reached.

I also recommend setting `params.where` like this:

`params.where[def.foreignKey] = instance[definition.idAttribute];`

instead of 

`params.where[def.foreignKey] = { '==': instance[definition.idAttribute] };`

because the former is a common syntax to use server side and will still be handled by your defaultFilter function browser side. Please let me know if it is not right.

Regards.