### PR TITLE
DS#find() returns items cached with DS#inject()

### DIFF
--- a/src/datastore/async_methods/find.js
+++ b/src/datastore/async_methods/find.js
@@ -21,7 +21,7 @@ export default function find(resourceName, id, options) {
       if (options.bypassCache || !options.cacheResponse) {
         delete resource.completedQueries[id];
       }
-      if (id in resource.completedQueries && _this.get(resourceName, id)) {
+      if ((!options.findStrictCache || id in resource.completedQueries) && _this.get(resourceName, id)) {
         resolve(_this.get(resourceName, id));
       } else {
         delete resource.completedQueries[id];

--- a/src/datastore/index.js
+++ b/src/datastore/index.js
@@ -101,6 +101,7 @@ defaultsPrototype.findBelongsTo = true;
 defaultsPrototype.findHasOne = true;
 defaultsPrototype.findHasMany = true;
 defaultsPrototype.findInverseLinks = true;
+defaultsPrototype.findStrictCache = true;
 defaultsPrototype.idAttribute = 'id';
 defaultsPrototype.ignoredChanges = [/\$/];
 defaultsPrototype.ignoreMissing = false;


### PR DESCRIPTION
DS#find() currently only returns the cached item early only if a
previous request was made to fetch the item. If the item was added using
DS#inject(), DS#find() will make a request anyways. This makes DS#find()
return the item directly instead.