### PR TITLE
Fix Events.off

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -160,7 +160,7 @@ function Events(target) {
       events = {};
     } else if (func) {
       for (let i = 0; i < listeners.length; i++) {
-        if (listeners[i] === func) {
+        if (listeners[i].f === func) {
           listeners.splice(i, 1);
           break;
         }


### PR DESCRIPTION
Events.off currently doesn't remove any listeners due to comparing the function against the handler object. Need to check `listeners[i].f` instead.