### PR TITLE
Added attribute to the definition of related fields to explicitly define the relationName

### DIFF
--- a/src/datastore/sync_methods/defineResource.js
+++ b/src/datastore/sync_methods/defineResource.js
@@ -103,7 +103,7 @@ module.exports = function defineResource(definition) {
           }
           DSUtils.forEach(relatedModels[relationName], d => {
             d.type = type;
-            d.relation = relationName;
+            d.relation = defs.relationName || relationName;
             d.name = def.name;
             def.relationList.push(d);
             if (d.localField) {


### PR DESCRIPTION
At the moment there can be only one relation from one model to another, because it is defined as a dictionary and the (unique-) key is the name of the related model.

But sometimes it is necessary to have more then one relation from a model to another. In my case a have a motion with one or more submitters and also one or more supporters.

With this patch the relation can be defined as followed:
```Javascript
...
hasMany: {
            'RandomString1': {
                localField: 'submitters',
                localKeys: 'submitters_id',
                relationName: 'users',
            },
            'RandomString2': {
                localField: 'supporters',
                localKeys: 'supporters_id',
                relationName: 'users',
            },
}
``` 