### PR TITLE
handleChange now batches DS.change events

### DIFF
--- a/mocha.start.js
+++ b/mocha.start.js
@@ -117,6 +117,7 @@ beforeEach(function () {
     beforeValidate: lifecycle.beforeValidate,
     cacheResponse: true,
     notify: true,
+    aggregateEvents: false,
     upsert: true,
     validate: lifecycle.validate,
     afterValidate: lifecycle.afterValidate,

--- a/src/datastore/index.js
+++ b/src/datastore/index.js
@@ -123,6 +123,7 @@ defaultsPrototype.logFn = function (a, b, c, d) {
 defaultsPrototype.maxAge = false
 defaultsPrototype.methods = {}
 defaultsPrototype.notify = !!DSUtils.w
+defaultsPrototype.aggregateEvents = false
 defaultsPrototype.omit = []
 defaultsPrototype.onConflict = 'merge'
 defaultsPrototype.reapAction = DSUtils.w ? 'inject' : 'none'

--- a/src/datastore/sync_methods/inject.js
+++ b/src/datastore/sync_methods/inject.js
@@ -313,11 +313,9 @@ module.exports = function inject (resourceName, attrs, options) {
     definition.emit('DS.beforeInject', definition, attrs)
   }
 
-  // start the recursive injection of data
+  // start the recursive injection of data; this will also call
+  // `definition.handleChange` for each item
   injected = _inject.call(_this, definition, resource, attrs, options)
-
-  // collection was modified
-  definition.handleChange(injected)
 
   // lifecycle
   options.afterInject(options, injected)

--- a/src/datastore/sync_methods/inject.js
+++ b/src/datastore/sync_methods/inject.js
@@ -317,6 +317,13 @@ module.exports = function inject (resourceName, attrs, options) {
   // `definition.handleChange` for each item
   injected = _inject.call(_this, definition, resource, attrs, options)
 
+  // If change aggregation is disabled, we emit a final event with all the
+  // inserted instances. If enabled, instance events will be aggregated into one
+  // for the same effect.
+  if (!definition.aggregateEvents) {
+    definition.handleChange(injected)
+  }
+
   // lifecycle
   options.afterInject(options, injected)
   if (options.notify) {


### PR DESCRIPTION
This solves the problem where a single `DS#inject` call would generate multiple resource-level change notifications.