### PR TITLE
Support maxAge in find/findAll requests (Issue #234)

### DIFF
--- a/src/datastore/async_methods/find.js
+++ b/src/datastore/async_methods/find.js
@@ -38,7 +38,12 @@ module.exports = function find (resourceName, id, options) {
       if (options.bypassCache || !options.cacheResponse) {
         delete resource.completedQueries[id]
       }
-      if ((!options.findStrictCache || id in resource.completedQueries) && definition.get(id) && !options.bypassCache) {
+
+      let expired = options.maxAge && id in resource.completedQueries &&
+            resource.completedQueries[id] + options.maxAge < new Date().getTime()
+
+      if ((!options.findStrictCache || id in resource.completedQueries) && definition.get(id) &&
+            !options.bypassCache && !expired) {
         // resolve immediately with the cached item
         resolve(definition.get(id))
       } else {

--- a/src/datastore/async_methods/findAll.js
+++ b/src/datastore/async_methods/findAll.js
@@ -75,7 +75,11 @@ module.exports = function findAll (resourceName, params, options) {
         delete resource.completedQueries[queryHash]
         delete resource.queryData[queryHash]
       }
-      if (queryHash in resource.completedQueries) {
+
+      let expired = options.maxAge && queryHash in resource.completedQueries &&
+            resource.completedQueries[queryHash] + options.maxAge < new Date().getTime()
+
+      if (queryHash in resource.completedQueries && !expired) {
         if (options.useFilter) {
           if (options.localKeys) {
             resolve(definition.getAll(options.localKeys, options.orig()))
@@ -92,7 +96,7 @@ module.exports = function findAll (resourceName, params, options) {
       }
     }
   }).then(function (items) {
-    if (!(queryHash in resource.completedQueries)) {
+    if (!items) {
       if (!(queryHash in resource.pendingQueries)) {
         let promise
         let strategy = options.findAllStrategy || options.strategy

--- a/test/browser/datastore/async_methods/find.test.js
+++ b/test/browser/datastore/async_methods/find.test.js
@@ -45,6 +45,61 @@ describe('DS#find', function () {
         assert.equal(lifecycle.deserialize.callCount, 2, 'deserialize should have been called');
       });
   });
+  it('should get an item from the server when expired', function () {
+    var _this = this;
+    Post.find(5);
+
+    assert.isUndefined(Post.get(5), 'The post should not be in the datastore yet');
+
+    // Respond to the request
+    setTimeout(function () {
+      assert.equal(1, _this.requests.length);
+      assert.equal(_this.requests[0].url, 'http://test.js-data.io/posts/5');
+      _this.requests[0].respond(200, { 'Content-Type': 'application/json' }, JSON.stringify(p1));
+    }, 100);
+
+    // Should have no effect because there is already a pending query
+    return Post.find(5, { maxAge: -1 })
+        .then(function (post) {
+          assert.deepEqual(JSON.stringify(post), JSON.stringify(p1));
+          assert.deepEqual(JSON.stringify(Post.get(5)), JSON.stringify(p1), 'The post is now in the datastore');
+          assert.isNumber(Post.lastModified(5));
+          assert.isNumber(Post.lastSaved(5));
+          assert.equal(1, _this.requests.length);
+
+          setTimeout(function () {
+            assert.equal(2, _this.requests.length);
+            assert.equal(_this.requests[1].url, 'http://test.js-data.io/posts/5');
+            _this.requests[1].respond(200, { 'Content-Type': 'application/json' }, JSON.stringify(p1));
+          }, 100);
+
+          // Should make a request because the request was already completed but is expired
+          return Post.find(5, { maxAge: -1 });
+        })
+        .then(function (post) {
+          assert.deepEqual(JSON.stringify(post), JSON.stringify(p1));
+          assert.equal(2, _this.requests.length);
+
+          // Should not make a request when maxAge is 0
+          return Post.find(5, { maxAge: 0 });
+        })
+        .then(function (post) {
+          assert.deepEqual(JSON.stringify(post), JSON.stringify(p1));
+          assert.equal(2, _this.requests.length);
+
+          // Should not make a request when maxAge is null
+          return Post.find(5, { maxAge: null });
+        })
+        .then(function (post) {
+          assert.deepEqual(JSON.stringify(post), JSON.stringify(p1));
+          assert.equal(2, _this.requests.length);
+
+          assert.equal(lifecycle.beforeInject.callCount, 2, 'beforeInject should have been called');
+          assert.equal(lifecycle.afterInject.callCount, 2, 'afterInject should have been called');
+          assert.equal(lifecycle.serialize.callCount, 0, 'serialize should have been called');
+          assert.equal(lifecycle.deserialize.callCount, 2, 'deserialize should have been called');
+        });
+  });
   it('should get an item from the server but not store it if cacheResponse is false', function () {
     var _this = this;
 


### PR DESCRIPTION
I kept your current structure (completedQueries = requests timestamp) and used maxAge to determine if item/query is expired.

Ideally, i think completedQueries should contain the expiration time instead of request time. That way, for future use, it would be easier to put an expiration time coming from an adapter instead of options.maxAge. Anyway, tell me if you think that way and i'll make another pull request.