### PR TITLE
Add save() option to always include specified properties when using changesOnly

### DIFF
--- a/src/datastore/async_methods/save.js
+++ b/src/datastore/async_methods/save.js
@@ -51,6 +51,9 @@ module.exports = function save (resourceName, id, options) {
         for (key in changes.changed) {
           toKeep.push(key)
         }
+        DSUtils.forEach(options.always, property => {
+          toKeep.push(property)
+        })
         changes = DSUtils.pick(attrs, toKeep)
         // no changes? no save
         if (DSUtils.isEmpty(changes)) {


### PR DESCRIPTION
Built off the idea from https://github.com/js-data/js-data-angular/pull/279.

Where would I place documentation? Let me know if you have any suggestions.