### PR TITLE
Add support for multiple parents

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "codacy-coverage": "1.1.3",
     "coveralls": "2.11.4",
     "es6-promise": "3.0.2",
-    "karma": "0.13.14",
+    "karma": "0.13.19",
     "karma-browserstack-launcher": "0.1.6",
     "karma-chai": "0.1.0",
     "karma-chrome-launcher": "0.2.1",

--- a/src/datastore/sync_methods/defineResource.js
+++ b/src/datastore/sync_methods/defineResource.js
@@ -118,12 +118,17 @@ module.exports = function defineResource (definition) {
         })
       })
       if (def.relations.belongsTo) {
+        def.parents = {}
         DSUtils.forOwn(def.relations.belongsTo, function (relatedModel, modelName) {
           DSUtils.forEach(relatedModel, function (relation) {
             if (relation.parent) {
               def.parent = modelName
               def.parentKey = relation.localKey
               def.parentField = relation.localField
+              def.parents[modelName] = {
+                key: def.parentKey,
+                field: def.parentField
+              }
             }
           })
         })

--- a/test/both/datastore/sync_methods/defineResource.test.js
+++ b/test/both/datastore/sync_methods/defineResource.test.js
@@ -303,4 +303,28 @@ describe('DS#defineResource', function () {
 
     assert.equal(Post[Post.class].name, 'Post');
   });
+
+  it('should add multiple parents to the parents property', function() {
+    var Permission = store.defineResource({
+      name: 'permission',
+      relations: {
+        belongsTo: {
+          user: {
+            parent: true,
+            localField: 'user',
+            localKey: 'userId'
+          },
+          group: {
+            parent: true,
+            localField: 'group',
+            localKey: 'groupId'
+          }
+        }
+      }
+    });
+
+    assert.property(Permission.parents, 'user')
+    assert.property(Permission.parents, 'group')
+    assert.lengthOf(Object.keys(Permission.parents), 2);
+  });
 });


### PR DESCRIPTION
This adds a `parents` property to the resource with all the parents.

The properties `parent`, `parentKey` and `parentField` are not removed for backwards compatibility.