### PR TITLE
Remove target param when calling target.set()

### DIFF
--- a/src/Schema.js
+++ b/src/Schema.js
@@ -1090,7 +1090,7 @@ export default Component.extend({
     utils.forOwn(properties, function (schema, prop) {
       if (schema.hasOwnProperty('default') && utils.get(target, prop) === undefined) {
         if (hasSet) {
-          target.set(target, prop, utils.plainCopy(schema['default']), { silent: true })
+          target.set(prop, utils.plainCopy(schema['default']), { silent: true })
         } else {
           utils.set(target, prop, utils.plainCopy(schema['default']))
         }


### PR DESCRIPTION
The first parameter when calling target.set() within Schema#applyDefaults is in error. This is not needed and it causes the defaults to not be applied.