### PR TITLE
Skip inverse deletion if is a hasMany type.

### DIFF
--- a/src/Relation.js
+++ b/src/Relation.js
@@ -154,6 +154,11 @@ utils.addHiddenPropsToTarget(Relation.prototype, {
 
   removeLinkedRecords (relatedMapper, records) {
     const localField = this.localField
+
+    // Skip if this is a hasMany.
+    if (this.inverse.type == HasManyRelation.TYPE_NAME) {
+      return;
+    }
     records.forEach((record) => {
       const relatedData = utils.get(record, localField)
       this.unlinkInverseRecords(relatedData)


### PR DESCRIPTION
If the inverted relationship of a is a hasMany, it will unset it during the removal of a record that is within the set. See http://plnkr.co/edit/6KenzTlIliOTZuSxuBBp?p=preview for an example.