### PR TITLE
fix(hasOne): do not create links for undefined or null keys

### DIFF
--- a/src/Relation.js
+++ b/src/Relation.js
@@ -193,6 +193,9 @@ utils.addHiddenPropsToTarget(Relation.prototype, {
 
   // e.g. user hasMany post via "foreignKey", so find all posts of user
   findExistingLinksByForeignKey (id) {
+    if (id === undefined || id === null) {
+      return
+    }
     return this.relatedCollection.filter({
       [this.foreignKey]: id
     })

--- a/src/Relation/HasOne.js
+++ b/src/Relation/HasOne.js
@@ -6,7 +6,7 @@ export const HasOneRelation = Relation.extend({
     const recordId = utils.get(record, relatedMapper.idAttribute)
     const records = this.findExistingLinksByForeignKey(recordId)
 
-    if (records.length) {
+    if (records && records.length) {
       return records[0]
     }
   }


### PR DESCRIPTION
`hasOne` links were being created in cases they should not.
- when no link existed, foreignKey was `undefined`
- we tried to filter on `relatedCollection` where the `foreignKey === undefined`
- this returned the entire set of records that did not actually have any related records, where in fact we don't want to find any relations in this case. 
