### PR TITLE
Inverse relation unlink bug

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -689,7 +689,6 @@ export default Component.extend({
         }
       }
     }
-    console.log(this.afterRemove)
     return this.afterRemove(idOrRecord, opts, record) || record
   },
 

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -689,6 +689,7 @@ export default Component.extend({
         }
       }
     }
+    console.log(this.afterRemove)
     return this.afterRemove(idOrRecord, opts, record) || record
   },
 

--- a/src/DataStore.js
+++ b/src/DataStore.js
@@ -1046,19 +1046,8 @@ const props = {
 
             // e.g. profile.user !== someUser
             // or comment.post !== somePost
-            if (currentParent) {
-              // e.g. otherUser.profile = undefined
-              if (inverseDef.type === hasOneType) {
-                safeSetLink(currentParent, inverseDef.localField, undefined)
-              } else if (inverseDef.type === hasManyType) {
-                // e.g. remove comment from otherPost.comments
-                const children = utils.get(currentParent, inverseDef.localField)
-                if (id === undefined) {
-                  utils.remove(children, (child) => child === this)
-                } else {
-                  utils.remove(children, (child) => child === this || id === utils.get(child, idAttribute))
-                }
-              }
+            if (currentParent && inverseDef) {
+              this.removeInverseRelation(currentParent, id, inverseDef, idAttribute)
             }
             if (record) {
               // e.g. profile.user = someUser
@@ -1077,18 +1066,8 @@ const props = {
               safeSetProp(this, foreignKey, relatedId)
               collection.updateIndex(this, updateOpts)
 
-              // Update (set) inverse relation
-              if (inverseDef.type === hasOneType) {
-                // e.g. someUser.profile = profile
-                safeSetLink(record, inverseDef.localField, this)
-              } else if (inverseDef.type === hasManyType) {
-                // e.g. add comment to somePost.comments
-                const children = utils.get(record, inverseDef.localField)
-                if (id === undefined) {
-                  utils.noDupeAdd(children, this, (child) => child === this)
-                } else {
-                  utils.noDupeAdd(children, this, (child) => child === this || id === utils.get(child, idAttribute))
-                }
+              if (inverseDef) {
+                this.setupInverseRelation(record, id, inverseDef, idAttribute)
               }
             } else {
               // Unset in-memory link only

--- a/src/DataStore.js
+++ b/src/DataStore.js
@@ -1,4 +1,5 @@
-import utils from './utils'
+import utils, { safeSetLink, safeSetProp } from './utils'
+
 import {
   belongsToType,
   hasManyType,
@@ -260,22 +261,6 @@ const ownMethodsForScoping = [
   'cacheFindAll',
   'hashQuery'
 ]
-
-const safeSetProp = function (record, field, value) {
-  if (record && record._set) {
-    record._set(`props.${field}`, value)
-  } else {
-    utils.set(record, field, value)
-  }
-}
-
-const safeSetLink = function (record, field, value) {
-  if (record && record._set) {
-    record._set(`links.${field}`, value)
-  } else {
-    utils.set(record, field, value)
-  }
-}
 
 const cachedFn = function (name, hashOrId, opts) {
   const cached = this._completedQueries[name][hashOrId]

--- a/src/DataStore.js
+++ b/src/DataStore.js
@@ -998,7 +998,6 @@ const props = {
     })
 
     const idAttribute = mapper.idAttribute
-
     mapper.relationList.forEach(function (def) {
       const relation = def.relation
       const localField = def.localField
@@ -1275,11 +1274,13 @@ const props = {
           get: getter,
           // e.g. user.profile = someProfile
           set (record) {
+            console.log("IN SET HAS ONE\n", this, path, this._get('links'), localField, "\n")
             const current = this._get(path)
             if (record === current) {
               return current
             }
             const inverseLocalField = def.getInverse(mapper).localField
+            console.log("SAFE SET LINK\n", current, inverseLocalField, record, "\n")
             if (record) {
               // Update (unset) inverse relation
               if (current) {
@@ -1302,6 +1303,15 @@ const props = {
               safeSetLink(record, inverseLocalField, this)
             } else {
               // Unset locals
+              if (current) {
+                console.log("SAFE SET FOREIGN KEY\n", current, foreignKey, "\n")
+                // Update (unset) inverse relation
+                /* Note that setting foreignKey to null / undefined breaks other specs
+                * Seems like there are other errors
+                */
+                // safeSetProp(current, foreignKey, undefined)
+                safeSetLink(current, inverseLocalField, undefined)
+              }
               safeSetLink(this, localField, undefined)
             }
             return record

--- a/src/DataStore.js
+++ b/src/DataStore.js
@@ -1274,13 +1274,11 @@ const props = {
           get: getter,
           // e.g. user.profile = someProfile
           set (record) {
-            console.log("IN SET HAS ONE\n", this, path, this._get('links'), localField, "\n")
             const current = this._get(path)
             if (record === current) {
               return current
             }
             const inverseLocalField = def.getInverse(mapper).localField
-            console.log("SAFE SET LINK\n", current, inverseLocalField, record, "\n")
             if (record) {
               // Update (unset) inverse relation
               if (current) {
@@ -1304,7 +1302,6 @@ const props = {
             } else {
               // Unset locals
               if (current) {
-                console.log("SAFE SET FOREIGN KEY\n", current, foreignKey, "\n")
                 // Update (unset) inverse relation
                 /* Note that setting foreignKey to null / undefined breaks other specs
                 * Seems like there are other errors

--- a/src/Record.js
+++ b/src/Record.js
@@ -392,7 +392,6 @@ export default Component.extend({
   },
 
   removeInverseRelation(currentParent, id, inverseDef, idAttribute) {
-    console.log('REMOVEINVERSERELATION')
     if (inverseDef.type === hasOneType) {
       safeSetLink(currentParent, inverseDef.localField, undefined)
     } else if (inverseDef.type === hasManyType) {

--- a/src/Record.js
+++ b/src/Record.js
@@ -1,4 +1,4 @@
-import utils from './utils'
+import utils, { safeSetLink } from './utils'
 import Component from './Component'
 import Settable from './Settable'
 import {

--- a/src/Record.js
+++ b/src/Record.js
@@ -1,6 +1,11 @@
 import utils from './utils'
 import Component from './Component'
 import Settable from './Settable'
+import {
+  belongsToType,
+  hasManyType,
+  hasOneType
+} from './decorators'
 
 const DOMAIN = 'Record'
 
@@ -384,6 +389,36 @@ export default Component.extend({
    */
   isValid (opts) {
     return !this._mapper().validate(this, opts)
+  },
+
+  removeInverseRelation(currentParent, id, inverseDef, idAttribute) {
+    if (inverseDef.type === hasOneType) {
+      safeSetLink(currentParent, inverseDef.localField, undefined)
+    } else if (inverseDef.type === hasManyType) {
+      // e.g. remove comment from otherPost.comments
+      const children = utils.get(currentParent, inverseDef.localField)
+      if (id === undefined) {
+        utils.remove(children, (child) => child === this)
+      } else {
+        utils.remove(children, (child) => child === this || id === utils.get(child, idAttribute))
+      }
+    }
+  },
+
+  setupInverseRelation(record, id, inverseDef, idAttribute) {
+      // Update (set) inverse relation
+    if (inverseDef.type === hasOneType) {
+      // e.g. someUser.profile = profile
+      safeSetLink(record, inverseDef.localField, this)
+    } else if (inverseDef.type === hasManyType) {
+      // e.g. add comment to somePost.comments
+      const children = utils.get(record, inverseDef.localField)
+      if (id === undefined) {
+        utils.noDupeAdd(children, this, (child) => child === this)
+      } else {
+        utils.noDupeAdd(children, this, (child) => child === this || id === utils.get(child, idAttribute))
+      }
+    }
   },
 
   /**

--- a/src/Record.js
+++ b/src/Record.js
@@ -392,6 +392,7 @@ export default Component.extend({
   },
 
   removeInverseRelation(currentParent, id, inverseDef, idAttribute) {
+    console.log('REMOVEINVERSERELATION')
     if (inverseDef.type === hasOneType) {
       safeSetLink(currentParent, inverseDef.localField, undefined)
     } else if (inverseDef.type === hasManyType) {
@@ -406,7 +407,7 @@ export default Component.extend({
   },
 
   setupInverseRelation(record, id, inverseDef, idAttribute) {
-      // Update (set) inverse relation
+    // Update (set) inverse relation
     if (inverseDef.type === hasOneType) {
       // e.g. someUser.profile = profile
       safeSetLink(record, inverseDef.localField, this)

--- a/src/Relation.js
+++ b/src/Relation.js
@@ -156,16 +156,13 @@ utils.addHiddenPropsToTarget(Relation.prototype, {
     const localField = this.localField
     records.forEach((record) => {
       const relatedData = utils.get(record, localField)
-      this.unlinkInverseRecords(relatedData)
+      /* CAN DEPRECATE? */
+      // this.unlinkInverseRecords(relatedData, record)
+
+      // descriptor.set will trigger removeInverseRelations
+      console.log("\nremoveLinkedRecords: RECORD - LOCALFIELD", record, localField, "\n")
       utils.set(record, localField, undefined)
     })
-  },
-
-  unlinkInverseRecords (record) {
-    if (!record) {
-      return
-    }
-    utils.set(record, this.getInverse(this.mapper).localField, undefined)
   },
 
   linkRecord (record, relatedRecord) {

--- a/src/Relation.js
+++ b/src/Relation.js
@@ -160,7 +160,6 @@ utils.addHiddenPropsToTarget(Relation.prototype, {
       // this.unlinkInverseRecords(relatedData, record)
 
       // descriptor.set will trigger removeInverseRelations
-      console.log("\nremoveLinkedRecords: RECORD - LOCALFIELD", record, localField, "\n")
       utils.set(record, localField, undefined)
     })
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -1576,6 +1576,23 @@ http://www.js-data.io/v3.0/docs/errors#${code}`
     }
 
     object[last] = undefined
+  },
+
+}
+
+export const safeSetProp = function (record, field, value) {
+  if (record && record._set) {
+    record._set(`props.${field}`, value)
+  } else {
+    utils.set(record, field, value)
+  }
+}
+
+export const safeSetLink = function (record, field, value) {
+  if (record && record._set) {
+    record._set(`links.${field}`, value)
+  } else {
+    utils.set(record, field, value)
   }
 }
 

--- a/test/unit/datastore/destroy.test.js
+++ b/test/unit/datastore/destroy.test.js
@@ -63,12 +63,14 @@ describe('DataStore#destroy', function () {
 
     const user = this.store.add('user', this.data.user10)
     assert.strictEqual(this.store.get('profile', this.data.profile15.id).user, user)
+    // console.log("TEST USER", user, "\n")
     assert.strictEqual(this.store.get('organization', this.data.organization14.id).users[0], user)
     assert.strictEqual(this.store.get('comment', this.data.comment11.id).user, user)
     assert.strictEqual(this.store.get('comment', this.data.comment12.id).user, user)
     assert.strictEqual(this.store.get('comment', this.data.comment13.id).user, user)
 
     const result = await this.store.destroy('user', user.id)
+    // assert.isTrue(this.store.get('profile', this.data.profile15.id).user == user)
     assert(destroyCalled, 'Adapter#destroy should have been called')
     assert.equal(this.store.get('profile', this.data.profile15.id).user, undefined)
     assert.equal(this.store.get('organization', this.data.organization14.id).users[0], undefined)

--- a/test/unit/decorators/belongsTo.test.js
+++ b/test/unit/decorators/belongsTo.test.js
@@ -77,6 +77,25 @@ describe('JSData.belongsTo', function () {
     assert.strictEqual(bar2.foo, foo)
     assert.strictEqual(bar3.foo, foo)
   })
+
+  it ('should not create an inverseLink if no inverseRelationship is defined', function() {
+    const store = new JSData.DataStore()
+    store.defineMapper('foo', {
+    })
+    store.defineMapper('bar', {
+      relations: {
+        belongsTo: {
+          foo: {
+            localField: '_foo',
+            foreignKey: 'foo_id'
+          }
+        }
+      }
+    })
+    const foo = store.add('foo', { id: 1 })
+    const bar = store.add('bar', { id: 1, foo_id: 1 })
+  })
+
   it('should add property accessors to prototype of target and allow relation re-assignment using customizations', function () {
     const store = new JSData.DataStore()
     store.defineMapper('foo', {

--- a/test/unit/decorators/belongsTo.test.js
+++ b/test/unit/decorators/belongsTo.test.js
@@ -94,6 +94,7 @@ describe('JSData.belongsTo', function () {
     })
     const foo = store.add('foo', { id: 1 })
     const bar = store.add('bar', { id: 1, foo_id: 1 })
+    assert.strictEqual(bar._foo, foo)
   })
 
   it('should add property accessors to prototype of target and allow relation re-assignment using customizations', function () {

--- a/test/unit/decorators/hasMany.test.js
+++ b/test/unit/decorators/hasMany.test.js
@@ -202,4 +202,40 @@ describe('JSData.hasMany', function () {
     assert.equal(getCalled, 11)
     assert.equal(setCalled, 2)
   })
+  it('unlinks correctly in related structures when a record is removed', function() {
+    const store = new JSData.DataStore();
+    const mapperA = store.defineMapper('A', {
+      properties: {
+        parent: { type: 'boolean' }
+      },
+      relations:  {
+        hasMany: {
+          B: {
+            localField: 'b',
+            foreignKey: 'a_id'
+          }
+        }
+      }
+    });
+    const mapperB = store.defineMapper('B', {
+      relations:  {
+        belongsTo: {
+          A: {
+            localField: 'a',
+            foreignKey: 'a_id'
+          }
+        }
+      }
+    });
+
+    // We add two records, which are not linked
+    const aRecord = store.add('A', {id: 1, parent: true});
+
+    store.add('B', [{id: 1, a_id: 1}, {id: 2, a_id: 1}]);
+    assert.equal(aRecord.b.length, 2, '2 items linked as expected');
+    console.log(aRecord.b)
+    store.remove('B', 2);
+    console.log(aRecord.b)
+    assert.equal(aRecord.b.length, 1, 'expected 1 item to still be linked but got empty array');
+  })
 })

--- a/test/unit/decorators/hasMany.test.js
+++ b/test/unit/decorators/hasMany.test.js
@@ -233,9 +233,7 @@ describe('JSData.hasMany', function () {
 
     store.add('B', [{id: 1, a_id: 1}, {id: 2, a_id: 1}]);
     assert.equal(aRecord.b.length, 2, '2 items linked as expected');
-    console.log(aRecord.b)
     store.remove('B', 2);
-    console.log(aRecord.b)
     assert.equal(aRecord.b.length, 1, 'expected 1 item to still be linked but got empty array');
   })
 })


### PR DESCRIPTION
ref: #376 Only the last commit is relevant (will rebase out after) but I built from my previous branch since I think the extraction helps readability. Basically JS-Data already goes down the `removeInverseRelation` pathway when a relation is set to `null/undefined` so `unlinkInverseRecords` is strictly unnecessary. 

Further the code in `unlinkInverseRecords` is flawed (or it would only work correctly for `hasOne`:

```es6
utils.set(record, this.getInverse(this.mapper).localField, undefined)
```
Compare to (`removeInverseRelation`): 
```es6
else if (inverseDef.type === hasManyType) {
  ...
 utils.remove(children, (child) => child === this || id === utils.get(child, idAttribute))
```

Unfortunately simply removing `removeInverseRelation` broke a test in the destroy suite. This is because the `hasOne` `setter()` does not clear correctly, so this was updated as well (see below). 


