### PR TITLE
Switch to passing only the current-change in 'changes' emit

### DIFF
--- a/src/Mapper.js
+++ b/src/Mapper.js
@@ -194,6 +194,16 @@ const MAPPER_DEFAULTS = {
   idAttribute: 'id',
 
   /**
+   * Whether records created from this mapper keep changeHistory on property changes.
+   *
+   * @default true
+   * @name Mapper#keepChangeHistory
+   * @since 3.0.0
+   * @type {boolean}
+   */
+  keepChangeHistory: true,
+
+  /**
    * Whether this Mapper should emit operational events.
    *
    * @default true

--- a/src/Record.js
+++ b/src/Record.js
@@ -134,6 +134,8 @@ function Record (props, opts) {
   if (id !== undefined) {
     utils.set(this, mapper.idAttribute, id)
   }
+  const keepChangeHistory = opts.keepChangeHistory !== undefined ? opts.keepChangeHistory : (mapper ? mapper.keepChangeHistory : true)
+  _set('keepChangeHistory', keepChangeHistory)
   utils.fillIn(this, props)
   _set('creating', false)
   _set('noValidate', false)

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -743,6 +743,8 @@ const creatingPath = 'creating'
 const eventIdPath = 'eventId'
 // boolean - Whether to skip validation for a Record's currently changing property
 const noValidatePath = 'noValidate'
+// boolean - Whether to preserve Change History for a Record
+const keepChangeHistoryPath = 'keepChangeHistory'
 // boolean - Whether to skip change notification for a Record's currently
 // changing property
 const silentPath = 'silent'
@@ -787,7 +789,6 @@ const makeDescriptor = function (prop, schema, opts) {
     const _get = this[getter]
     const _set = this[setter]
     const _unset = this[unsetter]
-
     // Optionally check that the new value passes validation
     if (!_get(noValidatePath)) {
       const errors = schema.validate(value, { path: [prop] })
@@ -802,23 +803,19 @@ const makeDescriptor = function (prop, schema, opts) {
     // TODO: Make it so tracking can be turned on for all properties instead of
     // only per-property
     if (track && !_get(creatingPath)) {
-      /* previous is versioned on database commit
-       * props are versioned on set()
-       * TODO? Option to disable props versioning (commit only versioning)
-       */
+      // previous is versioned on database commit
+      // props are versioned on set()
       const previous = _get(previousPath)
       const current = _get(keyPath)
       let changing = _get(changingPath)
       let changed = _get(changedPath)
 
-      // IS it possible for changing to be defined but changed undefined?
       if (!changing) {
         // Track properties that are changing in the current event loop
         changed = []
       }
 
       // Add changing properties to this array once at most
-      // Consider making changed into a Set ?
       const index = changed.indexOf(prop)
       if (current !== value && index === -1) {
         changed.push(prop)
@@ -861,11 +858,14 @@ const makeDescriptor = function (prop, schema, opts) {
             }
 
             const changes = utils.diffObjects({ [prop] : value }, { [prop] : current })
-            const changeRecord = utils.plainCopy(changes)
-            changeRecord.timestamp = new Date().getTime()
-            const changeHistory = _get(changeHistoryPath) || []
-            _set(changeHistoryPath, changeHistory)
-            changeHistory.push(changeRecord)
+
+            if (_get(keepChangeHistoryPath)) {
+              const changeRecord = utils.plainCopy(changes)
+              changeRecord.timestamp = new Date().getTime()
+              let changeHistory = _get(changeHistoryPath)
+              !changeHistory && _set(changeHistoryPath, (changeHistory = []))
+              changeHistory.push(changeRecord)
+            }
             this.emit('change', this, changes)
           }
           _unset(silentPath)

--- a/test/unit/record/hasChanges.test.js
+++ b/test/unit/record/hasChanges.test.js
@@ -1,4 +1,4 @@
-import { assert, JSData } from '../../_setup'
+import { assert, JSData, sinon } from '../../_setup'
 
 describe('Record#hasChanges', function () {
   it('should be an instance method', function () {
@@ -13,7 +13,7 @@ describe('Record#hasChanges', function () {
     post.author = 'Jake'
     assert(post.hasChanges())
   })
-  it('should return true if a tracked field is changed', function () {
+  it('should return true if a tracked field is changed', function (done) {
     const PostMapper = new JSData.Mapper({
       name: 'post',
       schema: {
@@ -26,10 +26,51 @@ describe('Record#hasChanges', function () {
       }
     })
     const post = PostMapper.createRecord(this.data.p1)
+    const listener = sinon.stub()
+    post.on('change', listener)
     assert(!post.hasChanges())
     post.author = 'Jake'
     assert(post.hasChanges())
     post.author = 'John'
     assert(!post.hasChanges())
+    setTimeout(function() {
+      assert.equal(listener.callCount, 0)
+      done()
+    }, 5)
+  }),
+
+  /* The previous test has a property set and changed back within a single event loop
+  * So no listener is ever called.
+  * This test checks that hasChanges() is still false (if the state is set back to the previous)
+  * even if both changes were registered and a listener was called on each change (twice in total).
+  */
+
+  it('is not affected by timing', function(done) {
+    const PostMapper = new JSData.Mapper({
+      name: 'post',
+      schema: {
+        properties: {
+          author: {
+            type: 'string',
+            track: true
+          }
+        }
+      }
+    })
+    const post = PostMapper.createRecord(this.data.p1)
+    const listener = sinon.stub()
+    post.on('change', listener)
+    post.author = 'Jake'
+    assert(post.hasChanges())
+    const secondSpec = function() {
+      assert.equal(listener.callCount, 2)
+      assert(!post.hasChanges())
+      done()
+    }
+    setTimeout(function () {
+      assert.equal(listener.callCount, 1)
+      post.author = 'John'
+      setTimeout(secondSpec, 5)
+    }, 5)
   })
 })

--- a/test/unit/record/on.test.js
+++ b/test/unit/record/on.test.js
@@ -1,6 +1,7 @@
 import { assert, JSData, sinon } from '../../_setup'
+const { Record } = JSData
 
-describe("Record#on('changes')", function() {
+describe("Record#on('change')", function() {
   it('Tracking changes to a single property', function(done) {
     const Store = new JSData.DataStore()
     const Foo = Store.defineMapper('foo', {
@@ -35,6 +36,51 @@ describe("Record#on('changes')", function() {
       assert.equal(Object.keys(changes.removed).length, 0)
       assert.equal(changes.added.name, 'new foo', "Only the property changed was emitted in the changeSet")
       secondSpec()
+    }, 5)
+  })
+
+  it('keepChangeHistory: false', function(done) {
+    const Store = new JSData.DataStore()
+
+    class FooRecord extends Record {
+      constructor(props, opts) {
+        super(props, opts)
+        this._set('keepChangeHistory', false)
+        this._set('noValidate', true)
+      }
+    }
+
+    const Foo = Store.defineMapper('foo', {
+      recordClass: FooRecord,
+      schema: {
+        properties: {
+          id: { type: 'number' },
+          name: { type: 'string', track: true }
+        }
+      },
+    })
+
+    const Bar = Store.defineMapper('bar', {
+      schema: {
+        properties: {
+          id: { type: 'number' },
+          name: { type: 'string', track: true }
+        }
+      },
+    })
+
+    const foo = Foo.createRecord()
+    const bar = Bar.createRecord()
+    const listener = sinon.stub()
+    foo.on('change', listener)
+    bar.on('change', listener)
+    foo.name = 'new foo'
+    bar.name = 'new bar'
+    setTimeout(function () {
+      assert.isTrue(listener.calledTwice, "on 'change' listener was called when modifying properties")
+      assert.deepEqual(foo.changeHistory(), [], "no changeHistory was stored if keepChangeHistory: false is set")
+      assert.equal(bar.changeHistory().length, 1, "if keepChangeHistory is true by default changeHistory is present")
+      done()
     }, 5)
   })
 })

--- a/test/unit/record/on.test.js
+++ b/test/unit/record/on.test.js
@@ -1,0 +1,40 @@
+import { assert, JSData, sinon } from '../../_setup'
+
+describe("Record#on('changes')", function() {
+  it('Tracking changes to a single property', function(done) {
+    const Store = new JSData.DataStore()
+    const Foo = Store.defineMapper('foo', {
+      schema: {
+        properties: {
+          id: { type: 'number' },
+          name: { type: 'string', track: true }
+        }
+      },
+    })
+    const foo = Foo.createRecord()
+    const listener = sinon.stub()
+    foo.on('change', listener)
+    foo.name = 'new foo'
+    const secondSpec = function() {
+      foo.name = 'updated foo'
+      setTimeout(function () {
+        const [record, changes] = listener.args[1]
+        assert.equal(foo, record, "on 'change' listener called with record which was modified")
+        assert.isTrue(listener.calledTwice, "on 'change' listener was called when modifying a property")
+        assert.equal(Object.keys(changes.added).length, 0)
+        assert.equal(Object.keys(changes.removed).length, 0)
+        assert.equal(changes.changed.name, 'updated foo', "Only the property changed was emitted in the changeSet")
+        done()
+      }, 5)
+    }
+    setTimeout(function () {
+      const [record, changes] = listener.args[0]
+      assert.equal(foo, record, "on 'change' listener called with record which was modified")
+      assert.isTrue(listener.calledOnce, "on 'change' listener was called when modifying a property")
+      assert.equal(Object.keys(changes.changed).length, 0)
+      assert.equal(Object.keys(changes.removed).length, 0)
+      assert.equal(changes.added.name, 'new foo', "Only the property changed was emitted in the changeSet")
+      secondSpec()
+    }, 5)
+  })
+})


### PR DESCRIPTION
This changes the diff function to use the previous `prop, value` pair rather than the `_get('previous')` which always diffs the committed state. #372 

One difference that accompanies this change is that while before a single changeHistory() entry contained all the changes to get to that history from `previous` now they would need to be merged. I'm not sure what the general practical applications for changeHistory are, so I don't know how having sparse vs. full-objects affects those. 