### PR TITLE
 Fix plaincopy() of Record to work with schema defined properties

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -331,12 +331,14 @@ const utils = {
         if (utils.isArray(to)) {
           to.length = 0
         } else {
-          utils.forOwn(to, function (value, key) {
+          utils.forOwnWithPrototype(from, function (value, key) {
             delete to[key]
           })
         }
-        for (var key in from) {
-          if (from.hasOwnProperty(key)) {
+
+        const proto = Object.getPrototypeOf(from)
+        for (var key of utils.keysWithPrototype(from)) {
+          if (from.hasOwnProperty(key) || proto.hasOwnProperty(key)) {
             if (utils.isBlacklisted(key, blacklist)) {
               continue
             }
@@ -764,6 +766,36 @@ http://www.js-data.io/v3.0/docs/errors#${code}`
     relationList.forEach(function (def) {
       utils._forRelation(opts, def, fn, thisArg)
     })
+  },
+
+  /**
+   * Returns the enumrable keys of an object and its prototype.
+   *
+   * @method utils.forOwnProperties
+   * @param {Object} object The object on which to lookup keys
+   * @returns {Object} Array of keys.
+   * @since 3.0.0
+   */
+  keysWithPrototype(obj) {
+    return Object.keys(Object.getPrototypeOf(obj)).concat(Object.keys(obj))
+  },
+
+  /**
+   * Iterate over an object's enumerable and prototype enumerable properties.
+   *
+   * @method utils.forOwnWithPrototype
+   * @param {Object} object The object whose properties are to be enumerated.
+   * @param {Function} fn Iteration function.
+   * @param {Object} [thisArg] Content to which to bind `fn`.
+   * @since 3.0.0
+   */
+  forOwnWithPrototype(obj, fn, thisArg) {
+    const keys = utils.keysWithPrototype(obj)
+    const len = keys.length
+    let i
+    for (i = 0; i < len; i++) {
+      fn.call(thisArg, obj[keys[i]], keys[i], obj)
+    }
   },
 
   /**

--- a/test/unit/utils/copy.test.js
+++ b/test/unit/utils/copy.test.js
@@ -95,6 +95,23 @@ describe('utils.copy', function () {
     })
   })
 
+  it('should copy Records including defined properties', function() {
+    const Store = new JSData.DataStore()
+    const Foo = Store.defineMapper('foo', {
+      schema: {
+        properties: {
+          id: { type: 'number' },
+          name: { type: 'string', track: true }
+        }
+      },
+    })
+    const foo = Foo.createRecord({name: 'a foo record'})
+    foo.arbitraryString = "I wasn't declared in properties"
+    const newFoo = utils.plainCopy(foo)
+    assert.equal(foo.name, newFoo.name)
+    assert.equal(foo.arbitraryString, newFoo.arbitraryString)
+  })
+
   it('copies arrays recursively', function () {
     assert.deepEqual(objCopy.structs.arrayOfPrimitives, srcObj.structs.arrayOfPrimitives)
     assert.notStrictEqual(objCopy.structs.arrayOfPrimitives, srcObj.structs.arrayOfPrimitives)


### PR DESCRIPTION
Fixes #374. I might be missing some edge-cases here, so this should probably come with significantly more tests. Especially I'm concerned about other places where `Object.keys`, `getOwnPropertyDescriptor`, `hasOwnProperty` are expecting to get the prototype descriptor when used on a record instance.