### PR TITLE
fix(SimpleStore): call Container.prototype.updateAll with correct order of params

### DIFF
--- a/src/SimpleStore.js
+++ b/src/SimpleStore.js
@@ -1792,7 +1792,7 @@ const props = {
    */
   updateAll (name, props, query, opts) {
     opts || (opts = {})
-    return Container.prototype.updateAll.call(this, name, query, props, opts)
+    return Container.prototype.updateAll.call(this, name, props, query, opts)
       .then((result) => this._end(name, result, opts))
   },
 

--- a/test/unit/datastore/updateAll.test.js
+++ b/test/unit/datastore/updateAll.test.js
@@ -16,7 +16,7 @@ describe('DataStore#updateAll', function () {
         return JSData.utils.resolve(props)
       }
     }, { 'default': true })
-    const users = await this.store.updateAll('user', query, props)
+    const users = await this.store.updateAll('user', props, query) 
     assert.equal(users[0].foo, 'bar', 'user was updated')
     assert(users[0] instanceof this.store.getMapper('user').recordClass, 'user is a record')
   })


### PR DESCRIPTION
`Container.updateAll` is a wrapper for `Mapper.updateAll` defined as 
```js
updateAll (props, query, opts) {}
```
`DataStore.updateAll` calls `Container.updateAll` passing `props` and `query` params in wrong order.
```js
updateAll (name, props, query, opts) {
    opts || (opts = {})
    return Container.prototype.updateAll.call(this, name, query, props, opts)
      .then((result) => this._end(name, result, opts))
}
```
