### PR TITLE
The check for the promisify function was outdated

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -414,7 +414,7 @@ export default {
       throw new DSErrors.IA('"options" must be an object!')
     }
     forEach(toPromisify, function (name) {
-      if (typeof options[name] === 'function' && options[name].toString().indexOf('for (var _len = arg') === -1) {
+      if (typeof options[name] === 'function' && options[name].toString().indexOf('for (var _len3 = arg') === -1) {
         options[name] = _this.promisify(options[name])
       }
     })


### PR DESCRIPTION
When iterating over functions on options objects the check for an existing promisify wrapper function was using an outdated string: `'for (var _len = arg'` instead of `'for (var _len3 = arg'`

This eventually caused stack overflows if the same options object was used for multiple calls on the datastore.