### PR TITLE
Fixes #471

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1504,12 +1504,14 @@ http://www.js-data.io/v3.0/docs/errors#${code}`
         _equal = _equal && utils.deepEqual(value, a[key])
       })
     } else if (utils.isArray(a) && utils.isArray(b)) {
-      a.forEach(function (value, i) {
-        _equal = _equal && utils.deepEqual(value, b[i])
-        if (!_equal) {
+      if (a.length !== b.length) {
+        return false
+      }
+      for (let i = a.length; i--;) {
+        if (!utils.deepEqual(a[i], b[i])) {
           return false
         }
-      })
+      }
     } else {
       return false
     }

--- a/test/unit/utils/deepEqual.test.js
+++ b/test/unit/utils/deepEqual.test.js
@@ -8,13 +8,19 @@ describe('utils.deepEqual', function () {
 
   it('does deep equal comparison', function () {
     const objA = { name: 'John', age: 90 }
+    const arrA = ['a', 'b', 'c']
+    const arrB = ['a', 'b', 'c', 'd', 'e']
+
     assert.isTrue(utils.deepEqual(2, 2), '2 deep equals 2')
     assert.isTrue(utils.deepEqual('test', 'test'), '"test" deep equals "test"')
     assert.isTrue(utils.deepEqual({}, {}), '{} deep equals {}')
     assert.isTrue(utils.deepEqual(objA, objA), objA + ' deep equals ' + objA)
+    assert.isTrue(utils.deepEqual(arrA, arrA), 'arrA deep equals arrA')
+
     assert.isFalse(utils.deepEqual(1, 2), '1 does not strict equal 2')
     assert.isFalse(utils.deepEqual(1, '1'), '1 does not strict equal "1"')
     assert.isFalse(utils.deepEqual('foo', 'bar'), '"foo" does not equal "bar')
+    assert.isFalse(utils.deepEqual(arrA, arrB), 'arrA does not deep equal arrB')
   })
 
   it('compares identical objects', function () {


### PR DESCRIPTION
Fixed the bug on equality check for Array raised in #471 

I also used a `for` loop instead of `forEach`, like this comparaison is recursive it can happen a lot, so it should used the fastest `for` possible.