### PR TITLE
disable pendingQueries optimizations when usePendingFind or usePendingFindAll are false

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
   ],
   "devDependencies": {
     "observe-js": "0.5.5",
-    "js-data-http": ">=2.0.0",
-    "js-data-localstorage": ">=2.0.0"
+    "js-data-http": "^2.0.0",
+    "js-data-localstorage": "^2.0.0"
   }
 }


### PR DESCRIPTION
Fixes #364 

- [x] - `npm test` succeeds
- [ ] - Code coverage does not decrease (if any source code was changed)
- [ ] - If applicable, appropriate JSDoc comments were updated in source code (if applicable)
- [ ] - If applicable, approprate changes to js-data.io docs have been suggested ("Suggest Edits" button)
