### PR TITLE
Filter related children by their own idAttribute, instead of that of the parent

### DIFF
--- a/src/Relation/HasMany.js
+++ b/src/Relation/HasMany.js
@@ -62,7 +62,7 @@ export const HasManyRelation = Relation.extend({
   findExistingLinksByLocalKeys (ids) {
     return this.relatedCollection.filter({
       where: {
-        [this.mapper.idAttribute]: {
+        [this.relatedCollection.mapper.idAttribute]: {
           'in': ids
         }
       }

--- a/test/integration/datastore.test.js
+++ b/test/integration/datastore.test.js
@@ -653,4 +653,54 @@ describe('DataStore integration tests', function () {
     assert.equal(nodes[4].parent, nodes[3])
     assert.deepEqual(nodes[4].children, [])
   })
+
+  it('should find hasMany foreignKeys with custom idAttribute', function () {
+    const store = new JSData.DataStore()
+
+    store.defineMapper('foo', {
+      relations: {
+        hasMany: {
+          bar: {
+            localField: 'bars',
+            localKeys: 'barIds'
+          }
+        }
+      },
+      idAttribute: 'fooId'
+    })
+    store.defineMapper('bar', {
+      relations: {
+        hasMany: {
+          foo: {
+            localField: 'foos',
+            foreignKeys: 'barIds'
+          }
+        }
+      }
+    })
+
+    const bars = store.add('bar', [
+      {
+        id: 0,
+        name: 'A'
+      },
+      {
+        id: 1,
+        name: 'B'
+      },
+      {
+        id: 2,
+        name: 'C'
+      }
+    ])
+
+    const foo = store.add('foo', {
+      fooId: 9,
+      name: 'Z',
+      barIds: [0, 2]
+    })
+
+    assert.isOk(foo.bars)
+    assert.deepEqual(foo.bars, [bars[0], bars[2]])
+  })
 })


### PR DESCRIPTION
Fixes #498.

- [X] - `npm test` succeeds
- [X] - Code coverage does not decrease (if any source code was changed)
