### PR TITLE
ci():  remove build job in circle ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,5 +17,4 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
       - test


### PR DESCRIPTION
The build job does not exist and was committed in circleci config by mistake