### PR TITLE
Revert "fix(utils): deepMixIn to properly merge undefined values of source"

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -409,7 +409,7 @@ const utils = {
         const existing = dest[key]
         if (isPlainObject(value) && isPlainObject(existing)) {
           utils.deepMixIn(existing, value)
-        } else if (existing === undefined || value !== undefined) {
+        } else {
           dest[key] = value
         }
       }

--- a/test/unit/utils/extendUtils.test.js
+++ b/test/unit/utils/extendUtils.test.js
@@ -54,15 +54,6 @@ describe('utils.deepMixIn', function () {
     assert.deepEqual(expected, actual, 'sorce own properties recursivly copied and overriden into dest')
     assert.equal(dest, utils.deepMixIn(dest), 'empty source argument returns dest')
   })
-
-  it('skips source properties that resolve to undefined if a destination value exists', function () {
-    const dest = { name: 'John', age: 90 }
-    const src = { name: 'John', age: undefined }
-    const expected = { name: 'John', age: 90 }
-    const actual = utils.deepMixIn(dest, src)
-
-    assert.deepEqual(expected, actual)
-  })
 })
 
 describe('utils.extend', function () {


### PR DESCRIPTION
Reverts js-data/js-data#502 - after some discussion, it was concluded that this could potentially be a breaking change to existing implementations.