### PR TITLE
Security Fix for Prototype Pollution

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -62,6 +62,7 @@ const mkdirP = function (object, path) {
   }
   const parts = path.split('.')
   parts.forEach(function (key) {
+    if (isPrototypePolluted(key)) return
     if (!object[key]) {
       object[key] = {}
     }
@@ -419,6 +420,7 @@ const utils = {
   deepFillIn (dest, source) {
     if (source) {
       utils.forOwn(source, function (value, key) {
+        if (isPrototypePolluted(key)) return
         const existing = dest[key]
         if (isPlainObject(value) && isPlainObject(existing)) {
           utils.deepFillIn(existing, value)


### PR DESCRIPTION
The previously patched fix is fixing only deepMixIn(), the vulnerability is still reproducible by using other methods like deepFillIn and set. 

Fixing the issues in set() and deepFillIn()

Reported in (Can you please validate these?)
https://www.huntr.dev/bounties/0391c0aa-a145-42bc-b402-02da110044f7/
https://www.huntr.dev/bounties/432bf9f6-23e3-4b0a-97eb-54f2a9d59afa/

- [ ] - `npm test` succeeds
- [X] - Code coverage does not decrease (if any source code was changed)
- [ ] - If applicable, appropriate JSDoc comments were updated in source code (if applicable)
- [ ] - If applicable, approprate changes to js-data.io docs have been suggested ("Suggest Edits" button)
